### PR TITLE
Fixed wrong version number

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -79,7 +79,7 @@
     You can install the build dependencies for Geary in Ubuntu by running this
     command:
 
-        $ sudo apt-get install valac-0.20 libgirepository1.0-dev intltool \
+        $ sudo apt-get install valac-0.22 libgirepository1.0-dev intltool \
             cmake desktop-file-utils gnome-doc-utils libcanberra-dev \
             libgee-0.8-dev libglib2.0-dev libgmime-2.6-dev libgtk-3-dev \
             libsecret-1-dev libxml2-dev libnotify-dev libsqlite3-dev \


### PR DESCRIPTION
Since "Building Geary requires Vala 0.22.1 or higher", it should be reflected in 'sudo apt-get install' too.
