### PR TITLE
Do not prefix src attribute twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bindings/vapi/gmime-2.6/gmime-2.6.gi
 /help/*/*.page
 !/help/C/*.page
 src/sqlite3-unicodesn/unicodesn.sqlext
+.vscode

--- a/src/client/conversation-viewer/conversation-viewer.vala
+++ b/src/client/conversation-viewer/conversation-viewer.vala
@@ -1496,7 +1496,10 @@ public class ConversationViewer : Gtk.Box {
                     if (!web_view.is_always_loaded(src)) {
                         // Workaround a WebKitGTK+ 2.4.10 crash. See Bug 763933
                         element.remove_attribute("src");
-                        element.set_attribute("src", web_view.allow_prefix + src);
+                        if (!src.has_prefix(web_view.allow_prefix)) {
+                             src = web_view.allow_prefix + src;
+                        }
+                        element.set_attribute("src", src);
                     }
                 }
             }


### PR DESCRIPTION
I noticed that sometimes src attribute of the img tag contains a url with double prefix, e.g:

```
ufijipwtbm:ufijipwtbm:http://s4.thcdn.com/widgets/96-en/49/580x384-z-RP-zavvi-foolsgold-055649.gif
```

That prevents Geary from loading images in emails.
