### PR TITLE
Add a keyboard shortcut for focusing the folder list

### DIFF
--- a/help/C/shortcuts.page
+++ b/help/C/shortcuts.page
@@ -55,8 +55,12 @@
   	    <td><p>Mark unread</p></td>
   		<td><p> <keyseq><key>Ctrl</key><key>U</key></keyseq> or <keyseq><key>Shift</key><key>U</key></keyseq> </p></td>
   	</tr>
+    <tr>
+      <td><p>Move focus to the folder list</p></td>
+      <td><p> <keyseq><key>Ctrl</key><key>H</key></keyseq> </p></td>
+    </tr>
   	<tr>
-  	    <td><p>Move focus to conversation list</p></td>
+  	    <td><p>Move focus to the conversation list</p></td>
   		<td><p> <keyseq><key>Ctrl</key><key>B</key></keyseq> </p></td>
   	</tr>
   	<tr>

--- a/src/client/application/geary-controller.vala
+++ b/src/client/application/geary-controller.vala
@@ -52,6 +52,7 @@ public class GearyController : Geary.BaseObject {
     public const string ACTION_MOVE_MENU = "GearyMoveMenuButton";
     public const string ACTION_GEAR_MENU = "GearyGearMenuButton";
     public const string ACTION_SEARCH = "GearySearch";
+    public const string ACTION_FOLDER_LIST = "GearyFolderList";
     public const string ACTION_CONVERSATION_LIST = "GearyConversationList";
     public const string ACTION_TOGGLE_SEARCH = "GearyToggleSearch";
     
@@ -528,6 +529,10 @@ public class GearyController : Geary.BaseObject {
         Gtk.ActionEntry search = { ACTION_SEARCH, null, null, null, null, on_search };
         entries += search;
         add_accelerator("<Ctrl>S", ACTION_SEARCH);
+
+        Gtk.ActionEntry folder_list = { ACTION_FOLDER_LIST, null, null, null, null, on_folder_list };
+        entries += folder_list;
+        add_accelerator("<Ctrl>H", ACTION_FOLDER_LIST);
         
         Gtk.ActionEntry conversation_list = { ACTION_CONVERSATION_LIST, null, null, null, null, on_conversation_list };
         entries += conversation_list;
@@ -1759,7 +1764,7 @@ public class GearyController : Geary.BaseObject {
         PreferencesDialog dialog = new PreferencesDialog(main_window);
         dialog.run();
     }
-    
+
     // latest_sent_only uses Email's Date: field, which corresponds to how they're sorted in the
     // ConversationViewer
     private Gee.ArrayList<Geary.EmailIdentifier> get_conversation_email_ids(
@@ -2659,6 +2664,10 @@ public class GearyController : Geary.BaseObject {
     
     private void on_search() {
         main_window.search_bar.give_search_focus();
+    }
+
+    private void on_folder_list() {
+        main_window.folder_list.grab_focus();
     }
     
     private void on_conversation_list() {


### PR DESCRIPTION
hello Geary

I'm was missing a keyboard shortcut for coming back to the folder list. so I've added one...

initially I wanted to do something like `Ctrl+1` for the folder list and `Ctrl+2` for the conversation list, because they're closer on the keyboard. however I've seen that there's already `Ctrl+B` for focusing the conversation list, so I went for `Ctrl+H` (as in _home_) for the folder list.

the most intuitive way to do it, in my opinion, would be to use `Tab` and `Ctrl+Tab` to switch back and forth through the three panes. however `Tab` also focuses through the toolbar and the email fields at the moment, so I didn't want to mess with that.

I'm not married to the bindings. looking forward to your feedback :dancers: 
