### PR TITLE
Set composer div text direction to auto

### DIFF
--- a/src/client/composer/composer-widget.vala
+++ b/src/client/composer/composer-widget.vala
@@ -125,7 +125,7 @@ public class ComposerWidget : Gtk.EventBox {
         }
         </style>
         </head><body>
-        <div id="message-body" contenteditable="true"></div>
+        <div id="message-body" contenteditable="true" dir="auto"></div>
         </body></html>""";
     private const string CURSOR = "<span id=\"cursormarker\"></span>";
     


### PR DESCRIPTION
This patch makes it possible to compose messages in RTL languages by setting dir="auto" to the composer div element. This means the div text direction is set based on the first strong directional character, which is consistent with other editors/word processors.
