### PR TITLE
Add menu setting to decoration-layout if it is missing

### DIFF
--- a/src/client/application/geary-controller.vala
+++ b/src/client/application/geary-controller.vala
@@ -170,6 +170,24 @@ public class GearyController : Geary.BaseObject {
         // Ensure all geary windows have an icon
         Gtk.Window.set_default_icon_name("geary");
 
+        // Fix for clients having both:
+        //   * disabled Gtk/ShellShowsAppMenu setting
+        //   * no 'menu' setting in Gtk/DecorationLayout
+        // See https://bugzilla.gnome.org/show_bug.cgi?id=770617
+        Gtk.Settings settings = Gtk.Settings.get_default();
+        assert(settings != null);
+
+        string decoration_layout = settings.gtk_decoration_layout;
+        assert(decoration_layout != null);
+
+        if (!decoration_layout.contains("menu")) {
+            string prefix = "menu:";
+            if (decoration_layout.contains(":")) {
+                prefix = (decoration_layout.has_prefix(":")) ? "menu" : "menu,";
+            }
+            settings.gtk_decoration_layout = prefix + settings.gtk_decoration_layout;
+        }
+
         // Setup actions.
         setup_actions();
         GearyApplication.instance.load_ui_resource("accelerators.ui");


### PR DESCRIPTION
Bug 770617

Check if gtk_decoration_layout contains menu setting.

Add it to the left if it is missing. This will force displaying menu for
clients having both:
- disabled Gtk/ShellShowsAppMenu setting
- no 'menu' setting in Gtk/DecorationLayout

which would have no possibility of using menu otherwise.

Tested on Gnome on Ubuntu 16.04 LTS by applying following settings:

With menu
`gsettings set org.gnome.settings-daemon.plugins.xsettings overrides "{'Gtk/ShellShowsAppMenu': <0>, 'Gtk/DecorationLayout': <'menu:minimize,maximize,close'>}"`

Without menu:
`gsettings set org.gnome.settings-daemon.plugins.xsettings overrides "{'Gtk/ShellShowsAppMenu': <0>, 'Gtk/DecorationLayout': <':minimize,maximize,close'>}"`

Empty decoration layout:
`gsettings set org.gnome.settings-daemon.plugins.xsettings overrides "{'Gtk/ShellShowsAppMenu': <0>, 'Gtk/DecorationLayout': <''>}"`

With stuff at the left
`gsettings set org.gnome.settings-daemon.plugins.xsettings overrides "{'Gtk/ShellShowsAppMenu': <0>, 'Gtk/DecorationLayout': <'minimize,maximize,close:'>}"`

Without separator
`gsettings set org.gnome.settings-daemon.plugins.xsettings overrides "{'Gtk/ShellShowsAppMenu': <0>, 'Gtk/DecorationLayout': <'minimize,maximize,close'>}"`
