### PR TITLE
Added support for lists in composer

### DIFF
--- a/icons/format-ordered-list-symbolic.svg
+++ b/icons/format-ordered-list-symbolic.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Capa_1" x="0px" y="0px" width="512px" height="512px" viewBox="0 0 533.333 533.333" style="enable-background:new 0 0 533.333 533.333;" xml:space="preserve">
+<g>
+	<path d="M183.333,433.333h333.333V500H183.333V433.333z M183.333,233.333h333.333V300H183.333V233.333z M183.333,33.333h333.333   V100H183.333V33.333z M83.333,0v133.333H50v-100H16.667V0H83.333z M50,273.958V300h66.667v33.333h-100v-76.042l66.667-31.25V200   H16.667v-33.333h100v76.042L50,273.958z M116.667,366.667v166.666h-100V500h66.667v-33.333H16.667v-33.334h66.667V400H16.667   v-33.333H116.667z" fill="#F2F2F2"/>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/icons/format-unordered-list-symbolic.svg
+++ b/icons/format-unordered-list-symbolic.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Capa_1" x="0px" y="0px" width="512px" height="512px" viewBox="0 0 533.333 533.333" style="enable-background:new 0 0 533.333 533.333;" xml:space="preserve">
+<g>
+	<path d="M0,0h133.333v133.333H0V0z M200,33.333h333.333V100H200V33.333z M0,200h133.333v133.333H0V200z M200,233.333h333.333V300   H200V233.333z M0,400h133.333v133.333H0V400z M200,433.333h333.333V500H200V433.333z" fill="#F6F5F5"/>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/src/client/composer/composer-web-view.vala
+++ b/src/client/composer/composer-web-view.vala
@@ -376,6 +376,14 @@ public class ComposerWebView : ClientWebView {
         this.call.begin(Geary.JS.callable("geary.indentLine"), null);
     }
 
+    public void insert_olist() {
+	this.call.begin(Geary.JS.callable("geary.insertOrderedList"), null);
+    }
+
+    public void insert_ulist() {
+	this.call.begin(Geary.JS.callable("geary.insertUnorderedList"), null);
+    }
+
     /**
      * Updates the signature block if it has not been deleted.
      */

--- a/src/client/composer/composer-widget.vala
+++ b/src/client/composer/composer-widget.vala
@@ -67,6 +67,8 @@ public class ComposerWidget : Gtk.EventBox {
     private const string ACTION_REMOVE_FORMAT = "remove-format";
     private const string ACTION_INDENT = "indent";
     private const string ACTION_OUTDENT = "outdent";
+    private const string ACTION_OLIST = "olist";
+    private const string ACTION_ULIST = "ulist";
     private const string ACTION_JUSTIFY = "justify";
     private const string ACTION_COLOR = "color";
     private const string ACTION_INSERT_IMAGE = "insert-image";
@@ -88,7 +90,8 @@ public class ComposerWidget : Gtk.EventBox {
     private const string[] html_actions = {
         ACTION_BOLD, ACTION_ITALIC, ACTION_UNDERLINE, ACTION_STRIKETHROUGH,
         ACTION_FONT_SIZE, ACTION_FONT_FAMILY, ACTION_COLOR, ACTION_JUSTIFY,
-        ACTION_INSERT_IMAGE, ACTION_COPY_LINK, ACTION_PASTE_WITH_FORMATTING
+        ACTION_INSERT_IMAGE, ACTION_COPY_LINK, ACTION_PASTE_WITH_FORMATTING,
+	ACTION_OLIST, ACTION_ULIST
     };
 
     private const ActionEntry[] action_entries = {
@@ -109,6 +112,8 @@ public class ComposerWidget : Gtk.EventBox {
         {ACTION_FONT_FAMILY,              on_font_family,            "s",     "'sans'"  },
         {ACTION_REMOVE_FORMAT,            on_remove_format,         null,      "false"  },
         {ACTION_INDENT,                   on_indent                                     },
+        {ACTION_OLIST,                    on_olist                                      },
+        {ACTION_ULIST,                    on_ulist                                      },
         {ACTION_OUTDENT,                  on_action                                     },
         {ACTION_JUSTIFY,                  on_justify,                "s",     "'left'"  },
         {ACTION_COLOR,                    on_select_color                               },
@@ -1804,6 +1809,14 @@ public class ComposerWidget : Gtk.EventBox {
 
     private void on_indent(SimpleAction action, Variant? param) {
         this.editor.indent_line();
+    }
+
+    private void on_olist(SimpleAction action, Variant? param) {
+	this.editor.insert_olist();
+    }
+
+    private void on_ulist(SimpleAction action, Variant? param) {
+	this.editor.insert_ulist();
     }
 
     private void on_mouse_target_changed(WebKit.WebView web_view,

--- a/ui/composer-web-view.js
+++ b/ui/composer-web-view.js
@@ -212,6 +212,12 @@ ComposerPageState.prototype = {
             element.setAttribute("type", "cite");
         }
     },
+    insertOrderedList: function() {
+        document.execCommand("insertOrderedList", false, null);
+    },
+    insertUnorderedList: function() {
+        document.execCommand("insertUnorderedList", false, null);
+    },
     updateSignature: function(signature) {
         if (this.signaturePart != null) {
             console.log(signature);

--- a/ui/composer-widget.ui
+++ b/ui/composer-widget.ui
@@ -506,6 +506,68 @@
                 <property name="position">1</property>
               </packing>
             </child>
+	    <child>
+	      <object class="GtkBox" id="list_buttons">
+		<property name="visible">True</property>
+		<property name="can_focus">False</property>
+		<child>
+		  <object class="GtkButton" id="olist_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="focus_on_click">False</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Insert ordered list</property>
+                    <property name="action_name">cmp.olist</property>
+                    <property name="always_show_image">True</property>
+                    <child>
+                      <object class="GtkImage" id="olist_image">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="pixel_size">16</property>
+                        <property name="icon_name">format-ordered-list-symbolic</property>
+                      </object>
+                    </child>
+		  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+		</child>
+		<child>
+		  <object class="GtkButton" id="ulist_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="focus_on_click">False</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Insert unordered list</property>
+                    <property name="action_name">cmp.ulist</property>
+                    <property name="always_show_image">True</property>
+                    <child>
+                      <object class="GtkImage" id="ulist_image">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="pixel_size">16</property>
+                        <property name="icon_name">format-unordered-list-symbolic</property>
+                      </object>
+                    </child>
+		  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+		</child>
+                <style>
+                  <class name="linked"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+	    </child>
             <child>
               <object class="GtkBox" id="indentation_buttons">
                 <property name="visible">True</property>
@@ -565,7 +627,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
             <child>
@@ -627,7 +689,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="position">4</property>
               </packing>
             </child>
             <child>
@@ -651,7 +713,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">4</property>
+                <property name="position">5</property>
               </packing>
             </child>
             <child>
@@ -675,7 +737,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">5</property>
+                <property name="position">6</property>
               </packing>
             </child>
             <child>
@@ -692,7 +754,7 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="pack_type">end</property>
-                <property name="position">5</property>
+                <property name="position">7</property>
               </packing>
             </child>
             <child>
@@ -707,7 +769,7 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="pack_type">end</property>
-                <property name="position">6</property>
+                <property name="position">8</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
This attempts to solve bug [#714921](https://bugzilla.gnome.org/show_bug.cgi?id=714921).

They are available as two buttons on the format bar, next to font
options. The icons I used are taken from a free icons site just for demo
purposes and should be replaced by new icons. Also I did not include
hotkeys mainly because I could not come up with a good one, also they
are pretty uncommon I think.